### PR TITLE
Update for 1.13+

### DIFF
--- a/src/net/axeora/eternallight/EternalLight.java
+++ b/src/net/axeora/eternallight/EternalLight.java
@@ -89,7 +89,7 @@ public class EternalLight extends JavaPlugin {
      */
     public boolean isLegacy() {
         byte[] ver = ReflectionUtil.getVersionUnsafe();
-        return ver.length > 1 && ver[1] <= 8;
+        return ver.length > 1 && ver[1] < Integer.parseInt(PluginData.MIN_SUPPORTED_VERSION.split("\\.")[1]);
     }
 
     public Projector getProjector() {

--- a/src/net/axeora/eternallight/EternalLight.java
+++ b/src/net/axeora/eternallight/EternalLight.java
@@ -41,43 +41,47 @@ public class EternalLight extends JavaPlugin {
     @Override
     public void onEnable() {
         instance = this;
-        if (isLegacy()) getLogger().info("Detected legacy version. Using legacy methods to support your version.");
 
-        api = new EternalLightAPI();
-        projector = new Projector();
-        Bukkit.getPluginManager().registerEvents(new PlayerMoveListener(), this);
-        Bukkit.getPluginManager().registerEvents(new PlayerConnectionListener(), this);
-        registerCommand(new LightCommand());
-        registerCommand(new ELCommand());
-
-        File file = new File(getDataFolder() + "/config.yml");
-        if (!file.exists()) {
-            saveDefaultConfig();
-            reloadConfig();
+        if (isLegacy()) {
+            getLogger().info("Detected legacy version. Disabling plugin!");
+            this.setEnabled(false);
         }
 
-        config = new EternalLightConfig();
-        config.init(this);
+        if (this.isEnabled()) {
+            api = new EternalLightAPI();
+            projector = new Projector();
+            Bukkit.getPluginManager().registerEvents(new PlayerMoveListener(), this);
+            Bukkit.getPluginManager().registerEvents(new PlayerConnectionListener(), this);
+            registerCommand(new LightCommand());
+            registerCommand(new ELCommand());
 
-        VersionChecker checker = new VersionChecker(PluginData.RESOURCE_ID, PluginData.VERSION);
-        checker.run(s -> {
-            if (s.getState() == VersionChecker.PluginVersionState.UNKNOWN) {
-                getLogger().log(Level.WARNING, "Failed to check plugin version. Are you running offline?");
+            File file = new File(getDataFolder() + "/config.yml");
+            if (!file.exists()) {
+                saveDefaultConfig();
+                reloadConfig();
             }
-            else if (s.getState() == VersionChecker.PluginVersionState.DEV_BUILD) {
-                ConsoleCommandSender sender = Bukkit.getConsoleSender();
-                sender.sendMessage(StringUtil.color("[EternalLight] \u00A7cYou are using a development build! Expect bugs."));
-            }
-            else if (s.getState() == VersionChecker.PluginVersionState.BEHIND) {
-                ConsoleCommandSender sender = Bukkit.getConsoleSender();
-                sender.sendMessage(StringUtil.color(""));
-                sender.sendMessage(StringUtil.color("&e New update available for " + PluginData.NAME));
-                sender.sendMessage(StringUtil.color(" Current version: &e" + PluginData.VERSION));
-                sender.sendMessage(StringUtil.color(" Latest version: &e" + s.getLatestVersion()));
-                sender.sendMessage(StringUtil.color(""));
-            }
-            this.versionMeta = s;
-        });
+
+            config = new EternalLightConfig();
+            config.init(this);
+
+            VersionChecker checker = new VersionChecker(PluginData.RESOURCE_ID, PluginData.VERSION);
+            checker.run(s -> {
+                if (s.getState() == VersionChecker.PluginVersionState.UNKNOWN) {
+                    getLogger().log(Level.WARNING, "Failed to check plugin version. Are you running offline?");
+                } else if (s.getState() == VersionChecker.PluginVersionState.DEV_BUILD) {
+                    ConsoleCommandSender sender = Bukkit.getConsoleSender();
+                    sender.sendMessage(StringUtil.color("[EternalLight] \u00A7cYou are using a development build! Expect bugs."));
+                } else if (s.getState() == VersionChecker.PluginVersionState.BEHIND) {
+                    ConsoleCommandSender sender = Bukkit.getConsoleSender();
+                    sender.sendMessage(StringUtil.color(""));
+                    sender.sendMessage(StringUtil.color("&e New update available for " + PluginData.NAME));
+                    sender.sendMessage(StringUtil.color(" Current version: &e" + PluginData.VERSION));
+                    sender.sendMessage(StringUtil.color(" Latest version: &e" + s.getLatestVersion()));
+                    sender.sendMessage(StringUtil.color(""));
+                }
+                this.versionMeta = s;
+            });
+        }
     }
 
     /**

--- a/src/net/axeora/eternallight/PluginData.java
+++ b/src/net/axeora/eternallight/PluginData.java
@@ -4,6 +4,7 @@ public class PluginData {
 
     public static final String NAME = "EternalLight";
     public static final String VERSION = "1.2";
+    public static final String MIN_SUPPORTED_VERSION = "1.13";
     public static final int RESOURCE_ID = 50961;
 
     public static final String PREFIX = "&e&l[" + NAME + "]&f ";

--- a/src/net/axeora/eternallight/cmd/ELCommand.java
+++ b/src/net/axeora/eternallight/cmd/ELCommand.java
@@ -19,6 +19,12 @@ public class ELCommand extends EternalCommand {
 
     @Override
     public boolean execute(CommandSender sender, String label, String[] args) {
+
+        // Check permissions
+        if (!testPermission(sender)) {
+            return false;
+        }
+
         if (args.length == 0) {
             msg(sender, "");
             msg(sender, "   &e&lEternal Light &7" + PluginData.VERSION);

--- a/src/net/axeora/eternallight/cmd/LightCommand.java
+++ b/src/net/axeora/eternallight/cmd/LightCommand.java
@@ -25,11 +25,19 @@ public class LightCommand extends EternalCommand {
 
     @Override
     public boolean execute(CommandSender sender, String s, String[] args) {
+
+        // Check if we're console
         if (sender instanceof ConsoleCommandSender) {
             Bukkit.getConsoleSender().sendMessage(StringUtil.color(
                     "[" + PluginData.NAME + "] &cOnly players can use this command!"));
             return false;
         }
+
+        // Check permissions
+        if (!testPermission(sender)) {
+            return false;
+        }
+
         Player player = (Player) sender;
         Projector projector = EternalLight.getInstance().getProjector();
         if (!projector.contains(player.getUniqueId())) projector.add(player);

--- a/src/net/axeora/eternallight/util/RGBParticle.java
+++ b/src/net/axeora/eternallight/util/RGBParticle.java
@@ -10,6 +10,7 @@ import java.awt.*;
 
 public class RGBParticle {
 
+    // 0 - 1
     private double r = 0, g = 0, b = 0;
 
     public RGBParticle() {}
@@ -59,12 +60,7 @@ public class RGBParticle {
     }
 
     public void send(Player player, double x, double y, double z) {
-        if (EternalLight.getInstance().isLegacy()) {
-            Location location = new Location(player.getWorld(), x, y, z);
-            player.spigot().playEffect(location, Effect.COLOURED_DUST, 0, 1,
-                    (float) r + 0.01F, (float) g, (float) b, 1, 0, 64);
-        } else {
-            player.spawnParticle(Particle.REDSTONE, x, y, z, 0, r + 0.0001, g, b, 1);
-        }
+        player.spawnParticle(Particle.REDSTONE, x, y, z, 0, new Particle.DustOptions(org.bukkit.Color.fromRGB(
+                (int)(r*255), (int)(g*255), (int)(b*255)), 1 ));
     }
 }


### PR DESCRIPTION
- Implemented new particle API to get working on 1.13+. `playEffect` has been deprecated, so this change effectively kills compatibility with everything before it (tho it might be worked around in the future)
For this reason I added a graceful shutdown routine for people attempting to run it on legacy versions.
- The command permissions werent doing any checks for some reason so that was fixed as well.