### PR TITLE
Update to reflect 1.18 spawning rules

### DIFF
--- a/src/me/masstrix/eternallight/handle/LightSpawnCase.java
+++ b/src/me/masstrix/eternallight/handle/LightSpawnCase.java
@@ -16,7 +16,7 @@ public enum LightSpawnCase {
 
     public static LightSpawnCase getCase(Block block) {
         World.Environment environment = block.getWorld().getEnvironment();
-        int base = environment == World.Environment.NETHER ? 11 : 7;
+        int base = environment == World.Environment.NETHER ? 11 : 0;
 
         if (block.getLightFromBlocks() > base) return NEVER;
         if (block.getLightFromSky() > base) return NIGHT_SPAWN;


### PR DESCRIPTION
Show "spawnable at night" and "spawnable all the time" when blocklight is = 0 skylight remains the same as well as nether rules